### PR TITLE
Successfully tested with andOTP 0.7.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ After this, you don't need to use DuOTP again, and may remove it from your devic
 
 * Google Authenticator for Android v5.00, GitHub release APK
 * [`de.kuix.android.apps.authenticator2`](https://github.com/kaie/otp-authenticator-android) version 1.0
+* [andOTP](https://github.com/andOTP/andOTP) version 0.7.1.1
 * Firefox for Android 68.3.0 (for browsing through the import process)
 
 ## Some technical details


### PR DESCRIPTION
Thank you so much for DuOTP! I didn't even imagine that this was possible. When scanning the Duo QR code failed, I assumed that Duo uses some proprietary mechanism rather than TOTP/HOTP and gave up on using the `Android` option. Today, I chanced upon your app in F-Droid and it worked!

Isn't it kinda ridiculous that Duo uses its own URL scheme than simply using `otpauth://hotp/`?